### PR TITLE
Removed `username` and `icon_emoji` from payload

### DIFF
--- a/slack_pull_reminder.py
+++ b/slack_pull_reminder.py
@@ -132,8 +132,6 @@ def send_to_slack(text):
     payload = {
         'token': SLACK_API_TOKEN,
         'channel': SLACK_CHANNEL,
-        'username': 'Pull Request Reminder',
-        'icon_emoji': ':bell:',
         'text': text
     }
 


### PR DESCRIPTION
Not to override Slack App settings, as per https://api.slack.com/methods/chat.postMessage#authorship:
>When the as_user parameter is set to false, messages are posted as "bot_messages", with message authorship attributed to the user name and icons associated with the Slack App.